### PR TITLE
修复有variant目录时的andFindConstraintReferencedIds命令遗漏资源的问题

### DIFF
--- a/plugin/src/main/java/com/xml/guard/XmlClassGuardPlugin.kt
+++ b/plugin/src/main/java/com/xml/guard/XmlClassGuardPlugin.kt
@@ -32,6 +32,13 @@ class XmlClassGuardPlugin : Plugin<Project> {
         project.afterEvaluate {
             android.applicationVariants.all { variant ->
                 val variantName = variant.name.capitalize()
+
+                val minifyTaskName = "minify${variant.name.capitalize()}WithR8"
+
+                if (project.tasks.findByName(minifyTaskName) == null) {
+                    return@all
+                }
+
                 if (guardExtension.findAndConstraintReferencedIds) {
                     createAndFindConstraintReferencedIds(project, variantName)
                 }
@@ -49,13 +56,14 @@ class XmlClassGuardPlugin : Plugin<Project> {
         val andResGuardTaskName = "resguard$variantName"
         val andResGuardTask = project.tasks.findByName(andResGuardTaskName)
             ?: throw GradleException("AndResGuard plugin required")
-        val findConstraintReferencedIdsTaskName = "andFindConstraintReferencedIds"
+        val findConstraintReferencedIdsTaskName = "andFind${variantName}ConstraintReferencedIds"
         val findConstraintReferencedIdsTask =
             project.tasks.findByName(findConstraintReferencedIdsTaskName)
                 ?: project.tasks.create(
                     findConstraintReferencedIdsTaskName,
                     FindConstraintReferencedIdsTask::class.java,
-                    andResGuard
+                    andResGuard,
+                    variantName
                 )
         andResGuardTask.dependsOn(findConstraintReferencedIdsTask)
     }
@@ -73,7 +81,8 @@ class XmlClassGuardPlugin : Plugin<Project> {
                 ?: project.tasks.create(
                     findConstraintReferencedIdsTaskName,
                     FindConstraintReferencedIdsTask::class.java,
-                    aabResGuard
+                    aabResGuard,
+                    variantName
                 )
         aabResGuardTask.dependsOn(findConstraintReferencedIdsTask)
     }

--- a/plugin/src/main/java/com/xml/guard/tasks/FindConstraintReferencedIdsTask.kt
+++ b/plugin/src/main/java/com/xml/guard/tasks/FindConstraintReferencedIdsTask.kt
@@ -4,8 +4,8 @@ import com.bytedance.android.plugin.extensions.AabResGuardExtension
 import com.tencent.gradle.AndResGuardExtension
 import com.xml.guard.model.aabResGuard
 import com.xml.guard.model.andResGuard
+import com.xml.guard.utils.fullVariantResDirs
 import com.xml.guard.utils.isAndroidProject
-import com.xml.guard.utils.resDirs
 import groovy.util.Node
 import groovy.xml.XmlParser
 import org.gradle.api.DefaultTask
@@ -20,7 +20,8 @@ import javax.inject.Inject
  * Time: 20:17
  */
 open class FindConstraintReferencedIdsTask @Inject constructor(
-    private val extensionName: String
+    private val extensionName: String,
+    private val variantName: String,
 ) : DefaultTask() {
 
     init {
@@ -32,7 +33,7 @@ open class FindConstraintReferencedIdsTask @Inject constructor(
         val layoutDirs = mutableListOf<File>()
         project.rootProject.subprojects {
             if (it.isAndroidProject()) {
-                it.resDirs().flatMapTo(layoutDirs) { dir ->
+                it.fullVariantResDirs(variantName = variantName).flatMapTo(layoutDirs) { dir ->
                     dir.listFiles { file ->
                         file.isDirectory && file.name.startsWith("layout")   //过滤res目录下的layout
                     }?.toList() ?: emptyList()

--- a/plugin/src/main/java/com/xml/guard/utils/ProjectExt.kt
+++ b/plugin/src/main/java/com/xml/guard/utils/ProjectExt.kt
@@ -51,6 +51,24 @@ fun Project.resDirs(path: String = ""): List<File> {
     return sourceSet.getByName("main").res.srcDirs.map { File(it, path) }
 }
 
+fun Project.fullVariantResDirs(path: String = "", variantName: String): List<File> {
+    println("fullVariantResDirs,variantName:$variantName")
+    val sourceSet = (extensions.getByName("android") as BaseExtension).sourceSets
+    val variants = splitVariantString(variantName)
+    variants.forEach {
+        println("fullVariantResDirs,variant:$it")
+    }
+    val fileList = mutableListOf<File>()
+    sourceSet.names.forEach { sourceFileName ->
+        println("fullVariantResDirs,sourceFileName:$sourceFileName")
+        if(sourceFileName.equals("main", true) || variants.contains(sourceFileName)) {
+            println("fullVariantResDirs,sourceFileName:$sourceFileName checked")
+            fileList.addAll(sourceSet.getByName(sourceFileName).res.srcDirs.map { File(it, path) })
+        }
+    }
+    return fileList
+}
+
 //返回manifest文件目录,有且仅有一个
 fun Project.manifestFile(): File {
     val sourceSet = (extensions.getByName("android") as BaseExtension).sourceSets
@@ -143,4 +161,9 @@ fun findClassByManifest(text: String, classPaths: MutableList<String>, packageNa
             classPaths.add(classPath)
         }
     }
+}
+
+private fun splitVariantString(variantName: String): List<String> {
+    val regex = Regex("(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+    return variantName.split(regex).map { it.lowercase() }
 }


### PR DESCRIPTION
当在source下存在多个variant时，andFindConstraintReferencedIds无法将除main之外的目录内的资源中constraint_referenced_ids的引用添加到AndResGuard的白名单中，本次PR主要通过以下两点来修复此问题：

1. 给andFindConstraintReferencedIds命令增加variant字段加以区分；
2. 修改FindConstraintReferencedIdsTask中获取目录的方法，增加除main文件夹之外的variant文件夹获取。

因未深入了解XmlClassGuard、moveDir和packageChange任务模块，本次修改仅针对andFindConstraintReferencedIds任务模块。